### PR TITLE
Add predictor importance optimization in OLS Synthetic Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We have implemented the following estimators including the traditional method Di
 | ----------- | ----------- |
 | [Difference-in-Difference (DID)](https://en.wikipedia.org/wiki/Difference_in_differences) | [Implemented through two-way fixed effects regression.](http://web.mit.edu/insong/www/pdf/FEmatch-twoway.pdf)       |
 | [De-biased Convex Panel Regression (DC-PR)](https://arxiv.org/abs/2106.02780) | Vivek Farias, Andrew Li, and Tianyi Peng. "Learning treatment effects in panels with general intervention patterns." Advances in Neural Information Processing Systems 34 (2021): 14001-14013. |
+| [Synthetic Control (OLS SC)](http://www.jstor.org/stable/3132164)   | Abadie, Alberto, and Javier Gardeazabal. “The Economic Costs of Conflict: A Case Study of the Basque Country.” The American Economic Review 93, no. 1 (2003): 113–32. |
 | [Synthetic Difference-in-Difference (SDID)](https://arxiv.org/pdf/1812.09970.pdf)   | Dmitry Arkhangelsky, Susan Athey, David A. Hirshberg, Guido W. Imbens, and Stefan Wager. "Synthetic difference-in-differences." American Economic Review 111, no. 12 (2021): 4088-4118. |
 | [Matrix Completion with Nuclear Norm Minimization (MC-NNM)](https://arxiv.org/abs/1710.10251)| Susan Athey, Mohsen Bayati, Nikolay Doudchenko, Guido Imbens, and Khashayar Khosravi. "Matrix completion methods for causal panel data models." Journal of the American Statistical Association 116, no. 536 (2021): 1716-1730. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "causaltensor"
 version = "0.1.8"
 description = "Package for causal inference in panels"
-authors = ["Tianyi Peng <tianyipeng95@gmail.com>"
+authors = ["Tianyi Peng <tianyipeng95@gmail.com>",
            "Arushi Jain <arushijain1154@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/src/causaltensor/cauest/OLSSyntheticControl.py
+++ b/src/causaltensor/cauest/OLSSyntheticControl.py
@@ -1,28 +1,32 @@
 import numpy as np
 from scipy.optimize import fmin_slsqp
-from toolz import partial
+from sklearn.metrics import mean_squared_error
 from causaltensor.cauest.panel_solver import PanelSolver
 from causaltensor.cauest.result import Result
 
 
 class OLSSCResult(Result):
-    def __init__(self, baseline = None, tau=None, beta=None, return_tau_scalar=False, individual_te=None):
+    def __init__(self, baseline = None, tau=None, beta=None, return_tau_scalar=False, individual_te=None, V=None):
         super().__init__(baseline = baseline, tau = tau, return_tau_scalar = return_tau_scalar)
-        self.beta = beta
+        self.beta = beta # control unit weights
         self.M = baseline # the counterfactual
         self.individual_te = individual_te
+        self.V = V  # predictor importance
 
 
 class OLSSCPanelSolver(PanelSolver):
-    def __init__(self, X, Z, pval=False):
+    def __init__(self, Y, Z, X=None, pval=False):
         """
-        @param X: T x N matrix to be regressed
+        @param Y: T x N matrix to be regressed
         @param Z: T x N intervention matrix of 0s and 1s
+        @param X: K x N covariates (optional)
         """
+        self.Y = Y
         self.X = X
-        self.T0, self.Y0, self.Y1, self.control_units, self.treatment_units = self.preprocess(Z)
+        self.T0, self.Y0, self.Y1, self.X0, self.X1, self.control_units, self.treatment_units = self.preprocess(Z)
         self.individual_te = np.zeros(len(self.treatment_units)) 
         self.pval = pval
+        
    
 
 
@@ -40,14 +44,20 @@ class OLSSCPanelSolver(PanelSolver):
         N = Z.shape[1]
         control_units = np.where(np.all(Z == 0, axis=0))[0]
         treatment_units = np.where(np.any(Z == 1, axis=0))[0]
-        Y0 = self.X[:, control_units]
-        Y1 = self.X[:, treatment_units]
+        Y0 = self.Y[:, control_units]
+        Y1 = self.Y[:, treatment_units]
+        if self.X is not None:
+            X0 = self.X[:, control_units]
+            X1 = self.X[:, treatment_units]
+        else:
+            X0 = None
+            X1 = None
         T0 = np.where(Z.any(axis=1))[0][0]
-        return T0, Y0, Y1, control_units, treatment_units
+        return T0, Y0, Y1, X0, X1, control_units, treatment_units
     
 
     
-    def ols_inference(self, Y1, Y0):
+    def ols_inference(self, Y1, Y0, X1=None, X0=None):
         """
         given some treatment outcome data as well as some control outcome data,
         create a synthetic control and estimate the average treatment effect of the intervention
@@ -57,34 +67,73 @@ class OLSSCPanelSolver(PanelSolver):
         @return counterfactual: counterfactual predicted by synthetic control
         @return tau: average treatment effect on test unit redicted by synthetic control
         """
-        def loss_w(W, X, y):
-            return np.sqrt(np.mean((y - X.dot(W))**2))
+        def loss_v(W, y_c, y_t):
+            return np.mean((y_t - y_c.dot(W))**2)
         
-        X = Y0[:self.T0] # control units in pre-intervention
-        y = Y1[:self.T0] # treatment unit in pre-intervention        
-        w_start = [1/X.shape[1]]*X.shape[1] # weights for each control units in synthetic control
+        def w_constraint(W, y_c, y_t): 
+            return np.sum(W) - 1
 
-        weights = fmin_slsqp(partial(loss_w, X=X, y=y),
-                            np.array(w_start),
-                            f_eqcons=lambda x: np.sum(x) - 1,
+
+        
+        y_c = Y0[:self.T0] # control units in pre-intervention
+        y_t = Y1[:self.T0] # treatment unit in pre-intervention        
+        w_start = np.array([1/y_c.shape[1]]*y_c.shape[1]) # weights for each control units in synthetic control
+
+        if X1 is not None:
+            v_start = np.array([1/X0.shape[0]]*X0.shape[0]) # weights for each predictor
+
+            def v_constraint(V, W, X0, X1, y_c, y_t): 
+                return np.sum(V) - 1
+            
+            def w_constraint(W, V, X0, X1): 
+                return np.sum(W) - 1
+
+            def loss_w(W, V, X0, X1):
+                return mean_squared_error(X1, X0.dot(W), sample_weight=V)
+            
+            def optimize_W(W, V, X0, X1): 
+                return fmin_slsqp(loss_w, W, bounds=[(0.0, 1.0)]*len(W), f_eqcons=w_constraint, 
+                                           args=(V, X0, X1), disp=False, full_output=True)[0]
+            
+            def optimize_V(V, W, X0, X1, y_c, y_t):
+                w_at_v = optimize_W(W, V, X0, X1)
+                return loss_v(w_at_v, y_c, y_t)
+            
+
+            V = fmin_slsqp(optimize_V, v_start, args=(w_start, X0, X1, y_c, y_t), bounds=[(0.0, 1.0)]*len(v_start), disp=False, f_eqcons=v_constraint, acc=1e-6)
+            W = optimize_W(w_start, V, X0, X1)
+            
+        else:
+            V = None
+            W = fmin_slsqp(loss_v, w_start, args=(y_c, y_t),
+                            f_eqcons=w_constraint,
                             bounds=[(0.0, 1.0)]*len(w_start),
                             disp=False)
         
-        M = Y0 @ weights
+        M = Y0 @ W
         tau = np.mean((Y1-M)[self.T0:])
-        return M, tau
+        return M, tau, W, V
         
 
     def fit(self):
         T = len(self.Y1)
+        V = []
+        weights = []
         tau = 0
-        M = np.copy(self.X)
+        M = np.copy(self.Y)
         self.individual_te = []
         for i, s in enumerate(self.treatment_units):
             Y1_s = self.Y1[:,i].reshape((T,))
-            counterfactual_s, tau_s = self.ols_inference(Y1_s, self.Y0)
+            if self.X is not None:
+                K = len(self.X1)
+                X1_s = self.X1[:,i].reshape((K,))
+                counterfactual_s, tau_s, W_s, V_s = self.ols_inference(Y1_s, self.Y0, X1_s, self.X0)
+                V.append(V_s)
+            else:
+                counterfactual_s, tau_s, W_s, V_s = self.ols_inference(Y1_s, self.Y0)
             tau += tau_s
             M[:, s] = counterfactual_s
+            weights.append(W_s)
             self.individual_te.append([s, tau_s])
         
         tau /= len(self.treatment_units)  
@@ -92,7 +141,7 @@ class OLSSCPanelSolver(PanelSolver):
         if self.pval:
             self.individual_te = self.permutation_test()
 
-        res = OLSSCResult(baseline = M, tau = tau, individual_te=self.individual_te)
+        res = OLSSCResult(baseline = M, tau = tau, individual_te=self.individual_te, beta=weights, V=V)
 
         
         return res
@@ -127,9 +176,13 @@ class OLSSCPanelSolver(PanelSolver):
 
 #backward compatability 
 
-def ols_synthetic_control(O, Z):
-    solver = OLSSCPanelSolver(O, Z)
+def ols_synthetic_control(O, Z, X=None):
+    solver = OLSSCPanelSolver(O, Z, X)
     res = solver.fit()
     return res.M, res.tau
+
+
+
+
 
 

--- a/src/causaltensor/tests/test_real_class.py
+++ b/src/causaltensor/tests/test_real_class.py
@@ -17,15 +17,17 @@ class TestRealClass:
     def create_dataset(self):
         file_path = os.path.join('tests', 'MLAB_data.txt')
         O_raw = np.loadtxt(file_path) # California Smoke Dataset
+        X = O_raw[1:8, :]  ## predictors
         O = O_raw[8:, :] ## remove features that are not relevant in this demo
         O = O.T
+        X = X.T
         Z = np.zeros_like(O) # Z has the same shape as O
         Z[-1, 19:] = 1
-        return O, Z
+        return O, Z, X
     
 
     def test_did(self, create_dataset):
-        O, Z = create_dataset
+        O, Z, _ = create_dataset
         M, tau = DID(O, Z)
         # TODO: Check for better assertions
         assert M.shape == O.shape
@@ -33,23 +35,27 @@ class TestRealClass:
 
 
     def test_sdid(self, create_dataset):
-        O, Z = create_dataset
+        O, Z, _ = create_dataset
         tau = SDID(O, Z)
         # TODO: Check for better assertions
         assert tau <= -10 and tau >= -20
 
 
     def test_synthetic_control(self, create_dataset):
-        O, Z = create_dataset
+        O, Z, X = create_dataset
+        # SC on only outcomes
         M, tau = ols_synthetic_control(O.T, Z.T)
-        # TODO: Check for better assertions
+        assert M.shape == O.T.shape
+        assert tau <= -10 and tau >= -20
+        # SC on predictors
+        M, tau = ols_synthetic_control(O.T, Z.T, X.T)
         assert M.shape == O.T.shape
         assert tau <= -10 and tau >= -20
 
  
 
     def test_dcpr(self, create_dataset):
-        O, Z = create_dataset
+        O, Z, _ = create_dataset
         M, tau, std = DC_PR_auto_rank(O, Z)
         # TODO: Check for better assertions
         assert M.shape == O.shape
@@ -64,7 +70,7 @@ class TestRealClass:
 
 
     def test_mc(self, create_dataset):
-        O, Z = create_dataset
+        O, Z, _ = create_dataset
         M, a, b, tau = MC_NNM_with_cross_validation(O, 1-Z)
         # TODO: Check for better assertions
         assert M.shape == O.shape


### PR DESCRIPTION
1. Extended OLS Synthetic Control to include predictors along with the outcomes and then optimizing for both predictor importance and control unit weights
2. Fixed a typo in the toml file